### PR TITLE
Menu button item for iOS 6

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -238,8 +238,14 @@ static SlideNavigationController *singletonInstance;
 	}
 	else
 	{
-		UIImage *image = [UIImage imageNamed:MENU_IMAGE];
-        return [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:selector];
+        UIImage *image = [UIImage imageNamed:MENU_IMAGE];
+        UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+        
+        [button setBounds:CGRectMake(0, 0, 18, 18)];
+        [button setImage:image forState:UIControlStateNormal];
+        [button addTarget:self action:selector forControlEvents:UIControlEventTouchUpInside];
+        
+        return [[UIBarButtonItem alloc] initWithCustomView:button];
 	}
 }
 


### PR DESCRIPTION
**Creating custom button to remove the transparent background of the menu button**

Button was introduced in iOS 6 with background color.
After this change the button remains usually presented in iOS 7 and the background was removed in iOS 6.
