### PR TITLE
Support switching of view controllers by setViewControllers method

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.h
+++ b/SlideMenu/Source/SlideNavigationController.h
@@ -54,6 +54,7 @@ typedef  enum{
 
 + (SlideNavigationController *)sharedInstance;
 - (void)switchToViewController:(UIViewController *)viewController withCompletion:(void (^)())completion;
+- (void)swapToViewController:(UIViewController *)viewController withCompletion:(void (^)())completion;
 - (void)bounceMenu:(Menu)menu withCompletion:(void (^)())completion;
 - (void)openMenu:(Menu)menu withCompletion:(void (^)())completion;
 - (void)closeMenuWithCompletion:(void (^)())completion;

--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -209,6 +209,44 @@ static SlideNavigationController *singletonInstance;
 	}
 }
 
+- (void)swapToViewController:(UIViewController *)viewController withCompletion:(void (^)())completion
+{
+    NSArray *viewControllers = [NSArray arrayWithObject:viewController];
+    
+	if (self.avoidSwitchingToSameClassViewController && [self.topViewController isKindOfClass:viewController.class])
+	{
+		[self closeMenuWithCompletion:completion];
+		return;
+	}
+    
+	if ([self isMenuOpen])
+	{
+		[UIView animateWithDuration:MENU_SLIDE_ANIMATION_DURATION
+							  delay:0
+							options:UIViewAnimationOptionCurveEaseOut
+						 animations:^{
+                             CGFloat width = self.horizontalSize;
+                             CGFloat moveLocation = (self.horizontalLocation> 0) ? width : -1*width;
+                             [self moveHorizontallyToLocation:moveLocation];
+                         } completion:^(BOOL finished) {
+                             
+                             [super setViewControllers:viewControllers animated:NO];
+                             
+                             [self closeMenuWithCompletion:^{
+                                 if (completion)
+                                     completion();
+                             }];
+                         }];
+	}
+	else
+	{
+        [super setViewControllers:viewControllers animated:YES];
+		
+		if (completion)
+			completion();
+	}
+}
+
 - (void)closeMenuWithCompletion:(void (^)())completion
 {
 	[self closeMenuWithDuration:MENU_SLIDE_ANIMATION_DURATION andCompletion:completion];


### PR DESCRIPTION
Currently, the switchToViewController method swaps the current view controller by popping to the root view controller then pushing another view controller on top of the stack. However, this causes the viewControllers array to contain two view controllers, which causes the displayed view controller to show a Back button in the NavigationBar. This is undesirable because the slide menu should be swapping view controllers between each selection, or clearing the viewControllers array before pushing a new view controller in.
