### PR TITLE
Added call to super in SlideNavigationController's viewWillTransitionToSize method

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -147,6 +147,8 @@ static SlideNavigationController *singletonInstance;
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
     self.menuNeedsLayout = YES;
 }
 


### PR DESCRIPTION
Not calling super is causing issues down the line such as:

http://stackoverflow.com/questions/25932642/uiimagepickercontroller-camera-view-rotating-strangely-on-ios-8-pictures