### PR TITLE
Use interface orientation instead of the device orientation (fixes #138)

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -395,7 +395,7 @@ static SlideNavigationController *singletonInstance;
 
 - (void)updateMenuFrameAndTransformAccordingToOrientation
 {
-	// Animate rotatation when menu is open and device rotates
+	// Animate rotatation when menu is open and interface rotates
 	CGAffineTransform transform = self.view.transform;
 	self.leftMenu.view.transform = transform;
 	self.rightMenu.view.transform = transform;
@@ -520,7 +520,7 @@ static SlideNavigationController *singletonInstance;
 - (void)moveHorizontallyToLocation:(CGFloat)location
 {
 	CGRect rect = self.view.frame;
-	UIDeviceOrientation orientation = [UIDevice currentDevice].orientation;
+	UIInterfaceOrientation orientation = [self interfaceOrientation];
 	Menu menu = (self.horizontalLocation >= 0 && location >= 0) ? MenuLeft : MenuRight;
     
     if ((location > 0 && self.horizontalLocation <= 0) || (location < 0 && self.horizontalLocation >= 0)) {
@@ -534,14 +534,14 @@ static SlideNavigationController *singletonInstance;
     }
     else
     {
-        if (UIDeviceOrientationIsLandscape(orientation))
+        if (UIInterfaceOrientationIsLandscape(orientation))
         {
             rect.origin.x = 0;
-            rect.origin.y = (orientation == UIDeviceOrientationLandscapeRight) ? location : location*-1;
+            rect.origin.y = (orientation == UIInterfaceOrientationLandscapeRight) ? location : location*-1;
         }
         else
         {
-            rect.origin.x = (orientation == UIDeviceOrientationPortrait) ? location : location*-1;
+            rect.origin.x = (orientation == UIInterfaceOrientationPortrait) ? location : location*-1;
             rect.origin.y = 0;
         }
     }
@@ -570,18 +570,18 @@ static SlideNavigationController *singletonInstance;
         return rect;
     }
 	
-	UIDeviceOrientation orientation = [UIDevice currentDevice].orientation;
+	UIInterfaceOrientation orientation = [self interfaceOrientation];
 	
-	if (UIDeviceOrientationIsLandscape(orientation))
+	if (UIInterfaceOrientationIsLandscape(orientation))
 	{
         // For some reasons in landscape below the status bar is considered y=0, but in portrait it's considered y=20
-        rect.origin.x = (orientation == UIDeviceOrientationLandscapeRight) ? 0 : STATUS_BAR_HEIGHT;
+        rect.origin.x = (orientation == UIInterfaceOrientationLandscapeRight) ? 0 : STATUS_BAR_HEIGHT;
         rect.size.width = self.view.frame.size.width-STATUS_BAR_HEIGHT;
 	}
 	else
 	{
         // For some reasons in landscape below the status bar is considered y=0, but in portrait it's considered y=20
-        rect.origin.y = (orientation == UIDeviceOrientationPortrait) ? STATUS_BAR_HEIGHT : 0;
+        rect.origin.y = (orientation == UIInterfaceOrientationPortrait) ? STATUS_BAR_HEIGHT : 0;
         rect.size.height = self.view.frame.size.height-STATUS_BAR_HEIGHT;
 	}
 	
@@ -610,7 +610,7 @@ static SlideNavigationController *singletonInstance;
 - (CGFloat)horizontalLocation
 {
 	CGRect rect = self.view.frame;
-	UIDeviceOrientation orientation = [UIDevice currentDevice].orientation;
+	UIInterfaceOrientation orientation = [self interfaceOrientation];
 	
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0"))
     {
@@ -618,15 +618,15 @@ static SlideNavigationController *singletonInstance;
     }
     else
     {
-        if (UIDeviceOrientationIsLandscape(orientation))
+        if (UIInterfaceOrientationIsLandscape(orientation))
         {
-            return (orientation == UIDeviceOrientationLandscapeRight)
+            return (orientation == UIInterfaceOrientationLandscapeRight)
             ? rect.origin.y
             : rect.origin.y*-1;
         }
         else
         {
-            return (orientation == UIDeviceOrientationPortrait)
+            return (orientation == UIInterfaceOrientationPortrait)
             ? rect.origin.x
             : rect.origin.x*-1;
         }
@@ -636,7 +636,7 @@ static SlideNavigationController *singletonInstance;
 - (CGFloat)horizontalSize
 {
 	CGRect rect = self.view.frame;
-	UIDeviceOrientation orientation = [UIDevice currentDevice].orientation;
+	UIInterfaceOrientation orientation = [self interfaceOrientation];
 	
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0"))
     {
@@ -644,7 +644,7 @@ static SlideNavigationController *singletonInstance;
     }
     else
     {
-        if (UIDeviceOrientationIsLandscape(orientation))
+        if (UIInterfaceOrientationIsLandscape(orientation))
         {
             return rect.size.height;
         }
@@ -677,7 +677,7 @@ static SlideNavigationController *singletonInstance;
 
 - (CGFloat)slideOffset
 {
-	return (UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation))
+	return (UIInterfaceOrientationIsLandscape([self interfaceOrientation]))
 		? self.landscapeSlideOffset
 		: self.portraitSlideOffset;
 }


### PR DESCRIPTION
Using the *interface* orientation instead of the *device* orientation fixes #138.