### PR TITLE
Bar buttons now update when changed

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -662,17 +662,21 @@ static SlideNavigationController *singletonInstance;
     [[NSNotificationCenter defaultCenter] postNotificationName:name object:nil userInfo:userInfo];
 }
 
+- (void)setBarButtonItemsForViewController:(UIViewController*)viewController {
+    if ([self shouldDisplayMenu:MenuLeft forViewController:viewController])
+        viewController.navigationItem.leftBarButtonItem = [self barButtonItemForMenu:MenuLeft];
+    
+    if ([self shouldDisplayMenu:MenuRight forViewController:viewController])
+        viewController.navigationItem.rightBarButtonItem = [self barButtonItemForMenu:MenuRight];
+}
+
 #pragma mark - UINavigationControllerDelegate Methods -
 
 - (void)navigationController:(UINavigationController *)navigationController
 	  willShowViewController:(UIViewController *)viewController
 					animated:(BOOL)animated
 {
-	if ([self shouldDisplayMenu:MenuLeft forViewController:viewController])
-		viewController.navigationItem.leftBarButtonItem = [self barButtonItemForMenu:MenuLeft];
-	
-	if ([self shouldDisplayMenu:MenuRight forViewController:viewController])
-		viewController.navigationItem.rightBarButtonItem = [self barButtonItemForMenu:MenuRight];
+    [self setBarButtonItemsForViewController:viewController];
 }
 
 - (CGFloat)slideOffset
@@ -880,6 +884,16 @@ static SlideNavigationController *singletonInstance;
     [_rightMenu.view removeFromSuperview];
     
     _rightMenu = rightMenu;
+}
+
+- (void)setLeftBarButtonItem:(UIBarButtonItem *)leftBarButtonItem {
+    _leftBarButtonItem = leftBarButtonItem;
+    [self setBarButtonItemsForViewController:self.topViewController];
+}
+
+- (void)setRightBarButtonItem:(UIBarButtonItem *)rightBarButtonItem {
+    _rightBarButtonItem = rightBarButtonItem;
+    [self setBarButtonItemsForViewController:self.topViewController];
 }
 
 @end


### PR DESCRIPTION
Love this subclass :). Had an issue while implementing it though: I created my `SlideNavigationController` using `- initWithRootViewController` (I don't use storyboards), and then I added a custom `leftBarButtonItem`, but the custom button wasn't showing up. I discovered that this is because the bar button items only update when a view controller is pushed onto the navigation stack. Since I was adding the custom button AFTER I added my root view controller, it wasn't getting updated. This patch overrides the setters on the bar button items such that they get updated whenever they're changed.
