### PR TITLE
Fix issue where navigationItem would not be displayed under iOS 7

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -125,9 +125,14 @@ static SlideNavigationController *singletonInstance;
 	self.portraitSlideOffset = MENU_DEFAULT_SLIDE_OFFSET;
 	self.panGestureSideOffset = 0;
 	self.avoidSwitchingToSameClassViewController = YES;
+	self.delegate = self;
+}
+
+- (void)viewDidLoad {
+	[super viewDidLoad];
+	
 	self.enableShadow = YES;
 	self.enableSwipeGesture = YES;
-	self.delegate = self;
 }
 
 - (void)viewWillLayoutSubviews


### PR DESCRIPTION
For reasons, that I currenlty do not understand, the self.enableShadow and
self.enableSwipeGesture calls in SlideNavigationController#setup cause problems
under iOS 7 in my setup.
I am instanciating a SlideNavigationController through a storyboard. While iOS
8 and 9 work fine, under iOS 7 I was seeing an empty navigation bar. It did
have a navigationItem, though that didn't match the topViewController and
didn't have any title or buttonItems.

I assume this issue arises from enableShadow and enableSwipeGesture both
accessing the view property, while being called before viewDidLoad.

Deferring both of these calls and making them during them during viewDidLoad
instead of during init, resolves the issue that I have been seeing under iOS 7.