### PR TITLE
Update SlideNavigationController with helper function - removeAllMenu…

### DIFF
--- a/SlideMenu/Source/SlideNavigationController.h
+++ b/SlideMenu/Source/SlideNavigationController.h
@@ -71,6 +71,7 @@ extern NSString  *const SlideNavigationControllerDidReveal;
 - (void)bounceMenu:(Menu)menu withCompletion:(void (^)())completion;
 - (void)openMenu:(Menu)menu withCompletion:(void (^)())completion;
 - (void)closeMenuWithCompletion:(void (^)())completion;
+- (void)removeAllMenuFromSuperview;
 - (void)toggleLeftMenu;
 - (void)toggleRightMenu;
 - (BOOL)isMenuOpen;

--- a/SlideMenu/Source/SlideNavigationController.m
+++ b/SlideMenu/Source/SlideNavigationController.m
@@ -608,6 +608,21 @@ static SlideNavigationController *singletonInstance;
 	[self.menuRevealAnimator prepareMenuForAnimation:menu];
 }
 
+- (void)removeAllMenuFromSuperview
+{
+    if (self.lastRevealedMenu == MenuLeft){
+        UIViewController *menuViewController = self.leftMenu;
+        [menuViewController.view removeFromSuperview];
+    } else if (self.lastRevealedMenu == MenuRight){
+        UIViewController *menuViewController = self.rightMenu;
+        [menuViewController.view removeFromSuperview];
+    }
+    
+    // Set lastRevealedMenu to Nil so we insert the Subview when prepareMenuForReveal is subsequently called
+    self.lastRevealedMenu = Nil;
+    return;
+}
+
 - (CGFloat)horizontalLocation
 {
 	CGRect rect = self.view.frame;


### PR DESCRIPTION
An issue a client of mine faced was with loading interstitial ads on top of the root controller.

The current library doesn't present a way to clean up the menu from the superview.

This function is only invoked when we switch from the left -> right menu, or vice versa.

Provided a public method that can be invoked in such circumstances that will clean up either the left or right menu (whichever is active) as well as reset the lastRevealedMenu